### PR TITLE
商品詳細表示機能(正)

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
   def item_params
     params.require(:item).permit(:name, :explain, :price, :image, :category_id, :item_status_id, :sending_charge_id, :sending_region_id, :sending_day_id,).merge(user_id: current_user.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: :index
+  before_action :move_to_index, except: [:index, :show]
 
   def index
   end

--- a/app/models/user_item.rb
+++ b/app/models/user_item.rb
@@ -1,0 +1,2 @@
+class UserItem < ApplicationRecord
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,19 +125,36 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
+        <li class='list'>
+        <div class='item-img-content'>
+          <%= image_tag item.image, class: "item-img" %>
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= item.name %>
+          </h3>
+          <div class='item-price'>
+            <span><%= item.price %>円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        </li>
+      <% end %>
+      
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
-
           <%# 商品が売れていればsold outの表示 %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outの表示 %>
-
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -154,28 +171,6 @@
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合のダミー %>
     </ul>
   </div>
   <%# //商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,9 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
         <li class='list'>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
+        <% link_to item_path(item.id), method: :get %>
           <%= image_tag item.image, class: "item-img" %>
         </div>
         <div class='item-info'>
@@ -143,6 +145,7 @@
             </div>
           </div>
         </div>
+        <% end %>
         </li>
       <% end %>
       

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,34 +4,32 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% else %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
 
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -40,27 +40,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.sending_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.sending_region.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.sending_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/db/migrate/20200820074913_create_user_items.rb
+++ b/db/migrate/20200820074913_create_user_items.rb
@@ -1,0 +1,9 @@
+class CreateUserItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_items do |t|
+      t.integer :user_id
+      t.integer :item_id
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200820074913_create_user_items.rb
+++ b/db/migrate/20200820074913_create_user_items.rb
@@ -1,8 +1,8 @@
 class CreateUserItems < ActiveRecord::Migration[6.0]
   def change
     create_table :user_items do |t|
-      t.integer :user_id
-      t.integer :item_id
+      t.references :user, foreign_key: true
+      t.references :item, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_16_030848) do
+ActiveRecord::Schema.define(version: 2020_08_20_074913) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -43,6 +43,13 @@ ActiveRecord::Schema.define(version: 2020_08_16_030848) do
     t.integer "sending_region_id"
     t.integer "sending_day_id"
     t.integer "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "item_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,10 +48,12 @@ ActiveRecord::Schema.define(version: 2020_08_20_074913) do
   end
 
   create_table "user_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "item_id"
+    t.bigint "user_id"
+    t.bigint "item_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_user_items_on_item_id"
+    t.index ["user_id"], name: "index_user_items_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
@@ -71,4 +73,6 @@ ActiveRecord::Schema.define(version: 2020_08_20_074913) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "user_items", "items"
+  add_foreign_key "user_items", "users"
 end

--- a/spec/factories/user_items.rb
+++ b/spec/factories/user_items.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user_item do
+    
+  end
+end

--- a/spec/models/user_item_spec.rb
+++ b/spec/models/user_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserItem, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
-ログアウト状態でも詳細画面へアクセスができるようにした。
 (index,showのみ許可しているため、購入できるのはログインユーザーのみ)
-DBのデータを、トップページの商品一覧に反映させるようにした。
-商品一覧の商品をクリックすると、詳細ページに遷移するようにした。
-編集・削除ボタンは出品者のみが踏めるように設定した。
-user_itemの中間テーブルを作成した。
-詳細ページに出品時登録情報を表示させるようにした。

# Why
商品詳細表示機能実装のため


# ログアウト状態で詳細ページ表示
<img width="1058" alt="ログアウト状態でも詳細ページは遷移できる" src="https://user-images.githubusercontent.com/68421387/90747626-21899980-e30c-11ea-8889-89f149f9ea33.png">

# トップページに商品一覧が表示され、クリックすると詳細ページへ遷移する
<img width="1289" alt="DB内容がトップページに表示されている図" src="https://user-images.githubusercontent.com/68421387/90747670-323a0f80-e30c-11ea-892f-31da4459fcef.png">

# 出品者が詳細ページを表示した場合の図
<img width="629" alt="出品者が詳細ページを表示した場合" src="https://user-images.githubusercontent.com/68421387/90747708-3cf4a480-e30c-11ea-8ca7-ee76c3e61afe.png">

# 出品者以外が詳細ページを表示した場合の図
<img width="676" alt="出品者以外が詳細ページを表示した場合" src="https://user-images.githubusercontent.com/68421387/90747738-4716a300-e30c-11ea-8f17-17f093dadbce.png">



